### PR TITLE
Testing the use of @ORM\Id on @ORM\ManyToOne.

### DIFF
--- a/src/Entity/TableA.php
+++ b/src/Entity/TableA.php
@@ -68,7 +68,7 @@ class TableA
     {
         if (!$this->tableB->contains($tableB)) {
             $this->tableB[] = $tableB;
-            $tableB->setTableA($this);
+            $tableB->tableA = $this;
         }
 
         return $this;

--- a/src/Entity/TableB.php
+++ b/src/Entity/TableB.php
@@ -48,18 +48,6 @@ class TableB
     public $bpk2;
 
     /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="AFK1")
-     */
-    public $afk1;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="AFK2")
-     */
-    public $afk2;
-
-    /**
      * @ORM\Column(type="string", name="FIELD1")
      */
     public $field1;
@@ -70,27 +58,14 @@ class TableB
     public $field2;
 
     /**
+     * @ORM\Id
      * @ORM\ManyToOne(targetEntity=TableA::class, inversedBy="tableB")
      * @ORM\JoinColumns(
      *     @ORM\JoinColumn(name="AFK1", referencedColumnName="APK1"),
      *     @ORM\JoinColumn(name="AFK2", referencedColumnName="APK2")
      * )
      */
-    private $tableA;
-
-    public function setTableA(TableA $tableA): self
-    {
-      $this->afk1 = $tableA->apk1;
-      $this->afk2 = $tableA->apk2;
-      $this->tableA = $tableA;
-
-      return $this;
-    }
-
-    public function getTableA(): TableA
-    {
-        return $this->tableA;
-    }
+    public $tableA;
 
     /**
      * @ORM\OneToMany(targetEntity=TableC::class, mappedBy="tableB")
@@ -105,7 +80,7 @@ class TableB
     {
         if (!$this->tableC->contains($tableC)) {
             $this->tableC[] = $tableC;
-            $tableC->setTableB($this);
+            $tableC->tableB = $this;
         }
 
         return $this;

--- a/src/Entity/TableC.php
+++ b/src/Entity/TableC.php
@@ -41,30 +41,6 @@ class TableC
     public $cpk1;
 
     /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="AFK1")
-     */
-    public $afk1;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="AFK2")
-     */
-    public $afk2;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="BFK1")
-     */
-    public $bfk1;
-
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="string", name="BFK2")
-     */
-    public $bfk2;
-
-    /**
      * @ORM\Column(type="string", name="FIELD1")
      */
     public $field1;
@@ -75,6 +51,7 @@ class TableC
     public $field2;
 
     /**
+     * @ORM\Id
      * @ORM\ManyToOne(targetEntity=TableB::class, inversedBy="tableC")
      * @ORM\JoinColumns(
      *     @ORM\JoinColumn(name="BFK1", referencedColumnName="BPK1"),
@@ -83,21 +60,5 @@ class TableC
      *     @ORM\JoinColumn(name="AFK2", referencedColumnName="AFK2"),
      * )
      */
-    private $tableB;
-
-    public function setTableB(TableB $tableB): self
-    {
-      $this->tableB = $tableB;
-      $this->afk1 = $tableB->afk1;
-      $this->afk2 = $tableB->afk2;
-      $this->bfk1 = $tableB->bpk1;
-      $this->bfk2 = $tableB->bpk2;
-
-      return $this;
-    }
-
-    public function getTableB(): TableB
-    {
-        return $this->tableB;
-    }
+    public $tableB;
 }


### PR DESCRIPTION
I'm doing some tests with [Doctrine](https://github.com/doctrine/orm) and a particular [existing schema](https://dbdiagram.io/d/5fc5f3413a78976d7b7e068e).

It seems that using `@ORM\Id` on `@ORM\ManyToOne` is [supported](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/tutorials/composite-primary-keys.html) in Doctrine, but not when it contains more than 2 join columns and foreign keys.

A workaround has been found to get this working and the solution is committed in the [master branch](https://github.com/drupol/composite/tree/master/) of this repository.
The published solution implies to:
* In a child entity, create a custom _getter_ for the parent linked entity and fiddle the foreign keys manually,
* Explicitly add each properties from the parent linked entity in the child entity.

However, I think that this is up to Doctrine to handle it. I definitely think it would so much better to just add the annotation `@ORM\Id` on fields having a `@ORM\ManyToOne` relation. Doctrine should be able to get the linked fields information from its parent linked entity, there is no need to add them twice or more.

I'm ready to make the changes in Doctrine so this would be supported but I would need some guidance first from the maintainers.

This PR is linked to:
* https://github.com/doctrine/orm/issues/8359

## Schema

* 3 entities: `A`, `B` and `C`.
* `B` has a `ManyToOne` relation to `A`.
* `C` has a `ManyToOne` relation to `B`.
* Each entities has a composite (_compound_) primary key.
* The primary keys of `B` and `C` are composed of natural fields and foreign keys from the parent entity.

See it on [DB Diagram](https://dbdiagram.io/d/5fc5f3413a78976d7b7e068e).
 
## Questions

* Is this supported in Doctrine?
* How much time would be needed to implement such a feature?

Current issues:

* `composer install`:

```
!!  In FileLoader.php line 173:
!!
!!    It is not possible to map entity 'App\Entity\TableA' with a composite prima
!!    ry key as part of the primary key of another entity 'App\Entity\TableB#tabl
!!    eA' in . (which is being imported from "/home/pol/dev/git/b4/echo/composite
!!    /config/routes/api_platform.yaml"). Make sure there is a loader supporting
!!    the "api_platform" type.
!!
!!
!!  In MappingException.php line 600:
!!
!!    It is not possible to map entity 'App\Entity\TableA' with a composite prima
!!    ry key as part of the primary key of another entity 'App\Entity\TableB#tabl
!!    eA'.
!!
```

* `bin/console doctrine:schema:create`

`It is not possible to map entity 'App\Entity\TableA' with a composite primary key as part of the primary key of another entity 'App\Entity\TableB#tableA'.
`
